### PR TITLE
New Serialix class implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ This project uses a [semantic versioning](https://semver.org/) scheme as the bas
 ### **2.1.0a1** : 2020
 
 #### Added
+- New class `Serialix` can be imported straight from package root and now will be a preferred way of creating instance of `serialix` for any supported language instead of using `*_Language` classes directly
 - `NotImplementedError` exception will now be raised when trying to execute any R/W-related action in class, inherited from `serialix.core.BaseLang` without defined `_core__read_file_to_dict` and `_core__write_dict_to_file` methods
 
 #### Changed

--- a/examples/simple_cli/cli.py
+++ b/examples/simple_cli/cli.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser, Namespace
 
-from serialix import JSON_Format
+from serialix import Serialix
 
 
 # Default dictionary, that will be used later
@@ -34,7 +34,8 @@ if __name__ == '__main__':
     args = parse_input_args()  # Parse input arguments
 
     # Prepare the configuration object
-    cfg = JSON_Format(
+    cfg = Serialix(
+        'json',            # Format of the used language
         'settings.json',   # Path to where local file will be located
         prog_default_dict  # Default dictionary, that will be used to
     )                      # fill the file on first creation

--- a/serialix/__init__.py
+++ b/serialix/__init__.py
@@ -7,9 +7,10 @@ from .meta import *
 from .serialix import Serialix
 from .langs.json import JSON_Format
 
+
 try:
     from .langs.yaml import YAML_Format
-except ImportError as e:
+except ImportError:
     pass
 
 try:

--- a/serialix/__init__.py
+++ b/serialix/__init__.py
@@ -4,6 +4,7 @@ it easier to access the main features of the
 other submodules and subpackages
 """
 from .meta import *
+from .serialix import Serialix
 from .langs.json import JSON_Format
 
 try:

--- a/serialix/core.py
+++ b/serialix/core.py
@@ -27,7 +27,7 @@ class BaseLang:
     :param parser_read_kwargs: Pass custom arguments to parser's read from local file action, defaults to {}
     :type parser_read_kwargs: dict, optional
     :raises ValueError: If provided data type in argument ``default_dictionary`` is not
-        the path ``str`` or ``dict``, this exception will be raised
+        the path ``str`` or ``dict``
 
     .. note::
         Methods ``.clear()``, ``.fromkeys()``, ``.get()``, ``.items()``, ``.keys()``, ``values()``,

--- a/serialix/langs/json.py
+++ b/serialix/langs/json.py
@@ -25,7 +25,7 @@ class JSON_Format(BaseLang):
     :param parser_read_kwargs: Pass custom arguments to parser's read from local file action, defaults to {}
     :type parser_read_kwargs: dict, optional
     :raises ValueError: If provided data type in argument ``default_dictionary`` is not
-        the path ``str`` or ``dict``, this exception will be raised
+        the path ``str`` or ``dict``
 
     .. note::
         Methods ``.clear()``, ``.fromkeys()``, ``.get()``, ``.items()``, ``.keys()``, ``values()``,

--- a/serialix/langs/toml.py
+++ b/serialix/langs/toml.py
@@ -22,7 +22,7 @@ class TOML_Format(BaseLang):
     :param parser_read_kwargs: Pass custom arguments to parser's read from local file action, defaults to {}
     :type parser_read_kwargs: dict, optional
     :raises ValueError: If provided data type in argument ``default_dictionary`` is not
-        the path ``str`` or ``dict``, this exception will be raised
+        the path ``str`` or ``dict``
 
     .. note::
         Methods ``.clear()``, ``.fromkeys()``, ``.get()``, ``.items()``, ``.keys()``, ``values()``,

--- a/serialix/langs/yaml.py
+++ b/serialix/langs/yaml.py
@@ -25,7 +25,7 @@ class YAML_Format(BaseLang):
     :param parser_read_kwargs: Pass custom arguments to parser's read from local file action, defaults to {}
     :type parser_read_kwargs: dict, optional
     :raises ValueError: If provided data type in argument ``default_dictionary`` is not
-        the path ``str`` or ``dict``, this exception will be raised
+        the path ``str`` or ``dict``
 
     .. note::
         Methods ``.clear()``, ``.fromkeys()``, ``.get()``, ``.items()``, ``.keys()``, ``values()``,

--- a/serialix/serialix.py
+++ b/serialix/serialix.py
@@ -1,0 +1,47 @@
+from .core import BaseLang
+
+
+class Serialix:
+    """
+    ``serialix`` unified instance generator for any officially supported language.
+
+    This class should be used for creation of the basic ``serialix`` object for one of the officially supported languages. Currently supported languages: ``json``, ``yaml``, ``toml``
+
+    :param file_format: Format of language to be used. Currently supported languages: ``json``, ``yaml`` (or ``yml``), ``toml`` (or ``tml``)
+    :type file_format: str
+    :param file_path: Path to preferred local file destination
+        If the file does not exist at the specified path, it will be created
+    :type file_path: str
+    :param default_dictionary: Default local file path ``str`` or ``dict``
+        that will be used for local file start values and , defaults to {}
+    :type default_dictionary: Union[str, dict], optional
+    :param auto_file_creation: Automatic local file creation on object initialization, defaults to True
+    :type auto_file_creation: bool, optional
+    :param force_overwrite_file: Whether the file needs to be overwritten if it already exists, defaults to False
+    :type force_overwrite_file: bool, optional
+    :param parser_write_kwargs: Pass custom arguments to parser's write to local file action, defaults to {}
+    :type parser_write_kwargs: dict, optional
+    :param parser_read_kwargs: Pass custom arguments to parser's read from local file action, defaults to {}
+    :type parser_read_kwargs: dict, optional
+    :raises ValueError: If provided data type in argument ``default_dictionary`` is not
+        the path ``str`` or ``dict``
+    :raises ValueError: If provided data in argument ``file_format`` is not one of the supported languages
+
+    .. versionadded:: 2.1.0
+    """
+    def __new__(self, file_format: str, file_path: str, default_dictionary={}, auto_file_creation=True, force_overwrite_file=False, parser_write_kwargs={}, parser_read_kwargs={}) -> BaseLang:
+        file_format = file_format.lower()
+        if file_format == 'json':
+            from .langs.json import JSON_Format
+
+            return JSON_Format(file_path=file_path, default_dictionary=default_dictionary, auto_file_creation=auto_file_creation, force_overwrite_file=force_overwrite_file, parser_write_kwargs=parser_write_kwargs, parser_read_kwargs=parser_read_kwargs)
+        elif file_format in ('yaml', 'yml'):
+            from .langs.yaml import YAML_Format
+
+            return YAML_Format(file_path=file_path, default_dictionary=default_dictionary, auto_file_creation=auto_file_creation, force_overwrite_file=force_overwrite_file, parser_write_kwargs=parser_write_kwargs, parser_read_kwargs=parser_read_kwargs)
+        elif file_format in ('toml', 'tml'):
+            from .langs.toml import TOML_Format
+
+            return TOML_Format(file_path=file_path, default_dictionary=default_dictionary, auto_file_creation=auto_file_creation, force_overwrite_file=force_overwrite_file, parser_write_kwargs=parser_write_kwargs, parser_read_kwargs=parser_read_kwargs)
+        else:
+            raise ValueError("'file_format' should be one of the supported languages name, not '{}'".format(file_format))


### PR DESCRIPTION
This PR will add new `Serialix` class, that can be imported straight from package root and now will be a preferred way of creating instance of `serialix` for any supported language instead of using `*_Language` classes directly